### PR TITLE
Issue #3 Update ActiveDirectoryFunctions.ps1 

### DIFF
--- a/source/module/ActiveDirectoryFunctions.ps1
+++ b/source/module/ActiveDirectoryFunctions.ps1
@@ -180,7 +180,7 @@ function New-SystemData
         {
             $computersContainer = (Get-ADDomain).ComputersContainer
             $targetMachines = (Get-ADComputer -SearchBase $computersContainer -Properties OperatingSystem -filter {OperatingSystem -like "*Windows 10*"} ).name
-            $ouFolder = "$SystemsPath\Computers Container Win10"
+            $ouFolder = "$SystemsPath\Windows 10"
         }
         else
         {

--- a/source/module/ActiveDirectoryFunctions.ps1
+++ b/source/module/ActiveDirectoryFunctions.ps1
@@ -178,8 +178,9 @@ function New-SystemData
         }
         elseif ($ou -eq "Computers")
         {
-            $targetMachines = (Get-ADComputer -Properties OperatingSystem -filter {OperatingSystem -like "*Windows 10*"} ).name
-            $ouFolder = "$SystemsPath\Windows 10"
+            $computersContainer = (Get-ADDomain).ComputersContainer
+            $targetMachines = (Get-ADComputer -SearchBase $computersContainer -Properties OperatingSystem -filter {OperatingSystem -like "*Windows 10*"} ).name
+            $ouFolder = "$SystemsPath\Computers Container Win10"
         }
         else
         {


### PR DESCRIPTION
Updated lines 181-183 to restrict the scope of targetmachines to only the Computer Container. In it's current state it is set grab all Win10 machines in domain which can cause duplicate system data files.

Issue #3 below  

![pr](https://user-images.githubusercontent.com/41164588/121725140-78847900-caae-11eb-9858-251545bb6660.PNG)
