### PR TITLE
Issue #13. New-SystemData -Localhost parameter only works for Windows 10 boxes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,20 +7,26 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Bug/Issue Description**
+Provide a clear and concise description the bug/issue
 
-**To Reproduce**
+**Reproduction Steps**
 Steps to reproduce the behavior:
 1. 
 2. 
 3. 
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Expected Behavior**
+A clear and concise description of what you expected to happen
+
+**Recommended fix action**
+If applicable, provide recommendations for how the bug/issue should be remediated
+
+**Existing Workarounds**
+If applicable, provide any existing workarounds for the bug/issue
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+If applicable, add screenshots to help explain your problem
 
 **Additional context**
 Add any other context about the problem here.

--- a/source/module/ActiveDirectoryFunctions.ps1
+++ b/source/module/ActiveDirectoryFunctions.ps1
@@ -113,35 +113,35 @@ function New-SystemData
         "AllServers"    {$targetMachines = @(Get-ADComputer -Filter {OperatingSystem -like "**server*"} -Properties "operatingsystem", "distinguishedname") ; break }
         "Full"          {$targetMachines = @(Get-ADComputer -Filter * -Properties "operatingsystem", "distinguishedname") ; break }
         "Targeted"      {$targetMachines = @(Get-AdComputer -Identity "$ComputerName" -Properties "operatingsystem","distinguishedname") ; break }
-        "Local" {
-
-        if ($osVersion -like '*Server*') {
-           
-            $targetMachines = @(
-                @{
-                    Name              = $env:computerName
-                    OperatingSystem   = $osVersion
-                    distinguishedname = "Servers"
-                }
-            )
-        }    
-        else 
+        "Local" 
         {
-            $targetMachines = @(
-                @{
-                    Name              = $env:computerName
-                    OperatingSystem   = $osVersion
-                    distinguishedname = "Computers"
-                }
-            )
+            if ($osVersion -like '*Server*') 
+            {           
+                $targetMachines = @(
+                    @{
+                        Name              = $env:computerName
+                        OperatingSystem   = $osVersion
+                        distinguishedname = "Servers"
+                    }
+                )
+            }    
+            else 
+            {
+                $targetMachines = @(
+                    @{
+                        Name              = $env:computerName
+                        OperatingSystem   = $osVersion
+                        distinguishedname = "Computers"
+                    }
+                )
+            }
         }
     }
-}
-
-    Write-Output "`tIdentifying Organizational Units for $($targetMachines.count) systems."
 
     if (-not($Localhost))
     {
+        Write-Output "`tIdentifying Organizational Units for $($targetMachines.count) systems."
+        
         if ($RootOrgUnit)
         {
             $orgUnits = Get-ADOrganizationalUnit -SearchBase $SearchBase -SearchScope OneLevel
@@ -186,6 +186,7 @@ function New-SystemData
         if ($LocalHost -or ($scope -eq "Local"))
         {
             $targetMachines = $env:ComputerName
+            $ou = "LocalHost"
             $ouFolder = "$SystemsPath\$env:computerName"
         }
         elseif ($ou -eq "Computers")


### PR DESCRIPTION
New-SystemData -Localhost parameter only works for Windows 10 boxes

Modified this to work for Servers as well.

Modified Line 120 to not use Static Win10 string. 
Also removed If statement in 235-242 since a machine name is retrieved while using localhost parameter.

Issue #13  