### PR TITLE
Initial Commit

### DIFF
--- a/source/module/ActiveDirectoryFunctions.ps1
+++ b/source/module/ActiveDirectoryFunctions.ps1
@@ -174,6 +174,11 @@ function New-SystemData
             $targetMachines = $env:ComputerName
             $ouFolder = "$SystemsPath\$env:computerName"
         }
+        elseif ($scope -eq "Targeted")
+        {
+        $targetMachines = $targetMachines.Name
+        $ouFolder = "$SystemsPath\$($ou.name)"
+        }
         elseif ($ou -eq "Computers")
         {
             $computersContainer = (Get-ADDomain).ComputersContainer

--- a/source/module/ActiveDirectoryFunctions.ps1
+++ b/source/module/ActiveDirectoryFunctions.ps1
@@ -176,8 +176,8 @@ function New-SystemData
         }
         elseif ($scope -eq "Targeted")
         {
-        $targetMachines = $targetMachines.Name
-        $ouFolder = "$SystemsPath\$($ou.name)"
+            $targetMachines = $targetMachines.Name
+            $ouFolder = "$SystemsPath\$($ou.name)"
         }
         elseif ($ou -eq "Computers")
         {


### PR DESCRIPTION
Scoped the Targeted/ComputerName parameter for New-SystemData. Without this, it will pull all servers from the OU no matter what's specified within the ComputerName parameter.

Issue #14 